### PR TITLE
increase `max_buffer_size`

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Expand the section below to see an example of the JSON diff output
 | `raw_diff_file_output` | no | - | Optionally write the raw diff output to a file. This is a string to the file path you wish to write to. **highly recommended** |
 | `file_output_only` | no | `"false"` | Only use file related outputs and do not print any diffs to console / loggers. **highly recommended** |
 | `search_path` | no | `.` | Optionally limit the scope of the diff operation to a specific sub-path. Useful for limiting scope of the action. |
-| `max_buffer_size` | no | `"1000000"` | Maximum output buffer size for call to git binary. Default is 1M, try increasing this value if you have issues with maxBuffer overflow. This value is technically a string but it gets converted to an integer. |
+| `max_buffer_size` | no | `"10000000"` | Maximum output buffer size for call to git binary. Default is 10M, try increasing this value if you have issues with maxBuffer overflow. This value is technically a string but it gets converted to an integer. |
 
 ## Outputs 📤
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     default: '.'
     required: false
   max_buffer_size:
-    description: Maximum output buffer size. Defaults to 1M, try increasing if you have issues. This value is technically a string but it gets converted to an integer.
+    description: Maximum output buffer size. Defaults to 10M, try increasing if you have issues. This value is technically a string but it gets converted to an integer.
     default: "10000000"
     required: false
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
   max_buffer_size:
     description: Maximum output buffer size. Defaults to 1M, try increasing if you have issues. This value is technically a string but it gets converted to an integer.
-    default: "1000000"
+    default: "10000000"
     required: false
 outputs:
   json-diff:


### PR DESCRIPTION
This pull request increases the `max_buffer_size` default value as GitHub Actions can handle the increase without issues.